### PR TITLE
Refine mobile hero layout and typography

### DIFF
--- a/assets/js/modules/home.js
+++ b/assets/js/modules/home.js
@@ -1,4 +1,10 @@
-import { $ } from './common.js';
+import { $, $$ } from './common.js';
+
+const getSlidesPerView = () => {
+  if (window.matchMedia('(min-width: 1024px)').matches) return 3;
+  if (window.matchMedia('(min-width: 768px)').matches) return 2;
+  return 1;
+};
 
 export const initHome = () => {
   const btn = $('#btnStart');
@@ -7,4 +13,143 @@ export const initHome = () => {
       window.location.href = 'login.html';
     });
   }
+
+  const viewport = $('.testimonial-window');
+  const track = viewport ? $('.testimonial-track', viewport) : null;
+  const cards = track ? $$('.testimonial-card', track) : [];
+  const prevBtn = $('.carousel-btn[data-dir="prev"]');
+  const nextBtn = $('.carousel-btn[data-dir="next"]');
+  const dotsHost = $('.carousel-dots');
+
+  if (!viewport || !track || cards.length === 0 || !prevBtn || !nextBtn || !dotsHost) {
+    return;
+  }
+
+  let index = 0;
+  let maxIndex = Math.max(0, cards.length - getSlidesPerView());
+  let autoTimer;
+  let scrollTimer;
+
+  const stopAuto = () => {
+    if (autoTimer) {
+      window.clearInterval(autoTimer);
+      autoTimer = undefined;
+    }
+  };
+
+  const startAuto = () => {
+    stopAuto();
+    if (maxIndex === 0) return;
+    autoTimer = window.setInterval(() => {
+      const nextIndex = index >= maxIndex ? 0 : index + 1;
+      goTo(nextIndex, { restartAuto: false });
+    }, 6000);
+  };
+
+  const syncButtons = () => {
+    const controlsDisabled = maxIndex === 0;
+    prevBtn.disabled = controlsDisabled || index <= 0;
+    nextBtn.disabled = controlsDisabled || index >= maxIndex;
+  };
+
+  const syncDots = () => {
+    const dots = Array.from(dotsHost.querySelectorAll('button'));
+    dots.forEach((dot, dotIndex) => {
+      dot.classList.toggle('active', dotIndex === index);
+      dot.setAttribute('aria-selected', dotIndex === index ? 'true' : 'false');
+    });
+    dotsHost.classList.toggle('hidden', maxIndex === 0);
+  };
+
+  const renderDots = () => {
+    dotsHost.innerHTML = '';
+    if (maxIndex === 0) {
+      syncDots();
+      return;
+    }
+
+    for (let i = 0; i <= maxIndex; i += 1) {
+      const dot = document.createElement('button');
+      dot.type = 'button';
+      dot.setAttribute('role', 'tab');
+      dot.setAttribute('aria-label', `Show testimonial ${i + 1}`);
+      dot.addEventListener('click', () => goTo(i));
+      dotsHost.append(dot);
+    }
+
+    syncDots();
+  };
+
+  const goTo = (targetIndex, { smooth = true, restartAuto = true } = {}) => {
+    const safeIndex = Math.max(0, Math.min(targetIndex, maxIndex));
+    const card = cards[safeIndex];
+    if (!card) return;
+
+    index = safeIndex;
+    viewport.scrollTo({ left: card.offsetLeft, behavior: smooth ? 'smooth' : 'auto' });
+    syncDots();
+    syncButtons();
+
+    if (restartAuto) {
+      startAuto();
+    }
+  };
+
+  const updateMetrics = ({ restart = true } = {}) => {
+    const slidesPerView = getSlidesPerView();
+    maxIndex = Math.max(0, cards.length - slidesPerView);
+    if (index > maxIndex) index = maxIndex;
+    renderDots();
+    goTo(index, { smooth: false, restartAuto: false });
+    syncButtons();
+    if (restart) {
+      if (maxIndex === 0) stopAuto();
+      else startAuto();
+    }
+  };
+
+  const updateIndexFromScroll = () => {
+    const { scrollLeft } = viewport;
+    let nearestIndex = index;
+    let minDistance = Number.POSITIVE_INFINITY;
+    cards.forEach((card, cardIndex) => {
+      const distance = Math.abs(card.offsetLeft - scrollLeft);
+      if (distance < minDistance) {
+        minDistance = distance;
+        nearestIndex = Math.min(cardIndex, maxIndex);
+      }
+    });
+    if (nearestIndex !== index) {
+      index = nearestIndex;
+      syncDots();
+      syncButtons();
+    }
+  };
+
+  prevBtn.addEventListener('click', () => goTo(index - 1));
+  nextBtn.addEventListener('click', () => goTo(index + 1));
+
+  viewport.addEventListener('pointerenter', stopAuto);
+  viewport.addEventListener('pointerleave', startAuto);
+  viewport.addEventListener('focusin', stopAuto);
+  viewport.addEventListener('focusout', startAuto);
+
+  viewport.addEventListener('scroll', () => {
+    stopAuto();
+    window.clearTimeout(scrollTimer);
+    scrollTimer = window.setTimeout(() => {
+      updateIndexFromScroll();
+      startAuto();
+    }, 120);
+  });
+
+  let resizeTimer;
+  window.addEventListener('resize', () => {
+    window.clearTimeout(resizeTimer);
+    resizeTimer = window.setTimeout(() => updateMetrics(), 150);
+  });
+
+  updateMetrics({ restart: false });
+  goTo(0, { smooth: false, restartAuto: false });
+  startAuto();
 };

--- a/home.html
+++ b/home.html
@@ -10,48 +10,161 @@
   <div id="header-placeholder"></div>
 
   <main class="container" id="page-home" role="main">
-    <section class="hero card">
-      <div class="hero-text">
-        <h1>Grow your tailoring business with confidence</h1>
-        <p class="muted">
-          Practical video lessons, simple calculators and access to partner banking products—designed for women entrepreneurs in small towns and villages.
+    <section class="hero card hero-accent">
+      <div class="hero-copy">
+        <span class="eyebrow">Built for women tailoring entrepreneurs</span>
+        <h1>Grow with practical lessons, tools &amp; trusted finance partners.</h1>
+        <p class="muted hero-support">
+          Learn at your own pace with short video lessons and smart calculators tailored for tailoring entrepreneurs.
         </p>
-        <div class="row gap" style="display:flex;gap:8px;align-items:center">
+        <p class="muted hero-support">
+          Access curated partner offers that help you price, save and invest confidently without leaving your shop.
+        </p>
+        <div class="hero-ctas">
           <button class="btn primary" id="btnStart">Login / Register</button>
           <a class="btn ghost" href="modules.html">Browse Programs</a>
         </div>
+        <dl class="hero-stats">
+          <div>
+            <dt>25k+</dt>
+            <dd class="muted">Lessons completed by tailors like you</dd>
+          </div>
+          <div>
+            <dt>4.8/5</dt>
+            <dd class="muted">Average rating for program quality</dd>
+          </div>
+          <div>
+            <dt>7 mins</dt>
+            <dd class="muted">Average time to finish a video</dd>
+          </div>
+        </dl>
       </div>
-      <img class="hero-art" src="img/img2.png" alt="Woman tailor learning with Samriddhi">
+      <div class="hero-visual" aria-hidden="true">
+        <div class="hero-glass">
+          <span class="badge">New module</span>
+          <h3>Plan your festive season orders</h3>
+          <ul class="bullets">
+            <li>Set the right blouse price</li>
+            <li>Track fabric usage &amp; profits</li>
+            <li>Offer installment savings</li>
+          </ul>
+          <div class="mini-card">
+            <strong>Bonus:</strong>
+            <p class="muted">Download the cashbook template loved by 5k tailors.</p>
+          </div>
+        </div>
+        <img class="hero-art" src="img/img2.png" alt="" role="presentation">
+      </div>
     </section>
 
-    <section class="info">
-      <article class="card">
-        <h3>Value Proposition</h3>
+    <section class="benefits">
+      <article class="card feature-card">
+        <div class="icon-bubble" aria-hidden="true">🎥</div>
+        <h3>Learn what matters</h3>
+        <p class="muted">Phone-first lessons in Marathi, Hindi and English so you can learn between customer orders.</p>
         <ul class="bullets">
-          <li>Phone-first learning in your language</li>
-          <li>Fair pricing & cashbook tools for tailors</li>
-          <li>Safe access to partner banking products</li>
+          <li>Short, practical how-to videos</li>
+          <li>Audio transcripts for quick revision</li>
+          <li>Downloadable checklists</li>
         </ul>
       </article>
-      <article class="card">
-        <h3>Why Samriddhi</h3>
+      <article class="card feature-card">
+        <div class="icon-bubble" aria-hidden="true">📈</div>
+        <h3>Run your business smoothly</h3>
+        <p class="muted">Use simple calculators and templates to price your work, manage cash flow and plan raw material purchases.</p>
         <ul class="bullets">
-          <li>Built for small towns & home businesses</li>
-          <li>Short, practical videos (5–10 minutes)</li>
-          <li>Trusted guidance on loans, FDs, RDs</li>
+          <li>Fair pricing calculator</li>
+          <li>Fabric &amp; trim planner</li>
+          <li>Cashbook with reminders</li>
         </ul>
       </article>
-      <article class="card">
-        <h3>Get started in minutes</h3>
-        <p class="muted">No email needed. Use your phone number and start learning today.</p>
-        <div><a class="btn primary" href="login.html">Login with phone</a></div>
+      <article class="card feature-card">
+        <div class="icon-bubble" aria-hidden="true">🤝</div>
+        <h3>Trustworthy finance partners</h3>
+        <p class="muted">Understand savings, insurance and loan products made for micro businesses with safe, guided onboarding.</p>
+        <ul class="bullets">
+          <li>Explain-it-simple guides</li>
+          <li>Compare offers in one view</li>
+          <li>Support from real coaches</li>
+        </ul>
       </article>
     </section>
 
-    <section class="testimonials">
-      <div class="card"><strong>Asha, Murbad</strong><p class="muted">“I learned to price blouses properly and doubled my monthly income.”</p></div>
-      <div class="card"><strong>Rekha, Jalgaon</strong><p class="muted">“The FD calculator helped me plan my savings without guesswork.”</p></div>
-      <div class="card"><strong>Farida, Osmanabad</strong><p class="muted">“Videos are short and clear—I learn between customer orders.”</p></div>
+    <section class="snapshot card">
+      <div>
+        <span class="eyebrow">Your business partner in one app</span>
+        <h2>Plan, learn and access capital without leaving your shop.</h2>
+        <p class="muted">Samriddhi brings together practical lessons, tools and curated partner offers, so you can focus on delighting customers and growing profits.</p>
+      </div>
+      <div class="snapshot-list">
+        <div class="snapshot-item">
+          <span class="icon-bubble" aria-hidden="true">✅</span>
+          <div>
+            <h4>Personalised learning tracks</h4>
+            <p class="muted">Get recommendations based on your goals and progress.</p>
+          </div>
+        </div>
+        <div class="snapshot-item">
+          <span class="icon-bubble" aria-hidden="true">💬</span>
+          <div>
+            <h4>Weekly coach nudges</h4>
+            <p class="muted">Stay motivated with reminders, WhatsApp tips and peer wins.</p>
+          </div>
+        </div>
+        <div class="snapshot-item">
+          <span class="icon-bubble" aria-hidden="true">🧮</span>
+          <div>
+            <h4>Smart calculators</h4>
+            <p class="muted">Make confident decisions on pricing, savings and repayments.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="testimonials card" aria-label="Learner testimonials">
+      <div class="testimonials-head">
+        <div>
+          <span class="eyebrow">Learners who trust Samriddhi</span>
+          <h2>Stories from tailoring entrepreneurs</h2>
+        </div>
+        <div class="testimonial-controls" aria-controls="testimonialCarousel">
+          <button class="carousel-btn" data-dir="prev" aria-label="Previous testimonial">
+            <span aria-hidden="true">◀</span>
+          </button>
+          <button class="carousel-btn" data-dir="next" aria-label="Next testimonial">
+            <span aria-hidden="true">▶</span>
+          </button>
+        </div>
+      </div>
+      <div class="testimonial-window" id="testimonialCarousel">
+        <div class="testimonial-track">
+          <article class="testimonial-card">
+            <blockquote>
+              “I learned to price blouses properly and doubled my monthly income.”
+            </blockquote>
+            <cite>Asha, Murbad</cite>
+          </article>
+          <article class="testimonial-card">
+            <blockquote>
+              “The FD calculator helped me plan my savings without guesswork.”
+            </blockquote>
+            <cite>Rekha, Jalgaon</cite>
+          </article>
+          <article class="testimonial-card">
+            <blockquote>
+              “Videos are short and clear—I learn between customer orders.”
+            </blockquote>
+            <cite>Farida, Osmanabad</cite>
+          </article>
+          <article class="testimonial-card">
+            <blockquote>
+              “Coach nudges on WhatsApp remind me to finish lessons every week.”
+            </blockquote>
+            <cite>Shilpa, Ahmednagar</cite>
+          </article>
+        </div>
+      </div>
+      <div class="carousel-dots" role="tablist" aria-label="Testimonial slide indicators"></div>
     </section>
   </main>
 

--- a/styles.css
+++ b/styles.css
@@ -39,7 +39,7 @@ body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetic
 .login-pill{background:#0f172a;color:#fff;border:0;border-radius:14px;padding:10px 16px;font-weight:800;cursor:pointer}
 
 /* Buttons */
-.btn{cursor:pointer}
+.btn{cursor:pointer;display:inline-flex;align-items:center;justify-content:center;font-weight:600;text-decoration:none}
 .btn.primary{background:var(--brand);color:#fff;border:0;border-radius:12px;padding:10px 16px}
 .btn.ghost{background:transparent;border:1px dashed var(--border);color:var(--text);border-radius:12px;padding:10px 16px}
 .btn.small{padding:8px 12px;border-radius:10px}
@@ -48,15 +48,84 @@ body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetic
 .progress > span{display:block;height:100%;background:linear-gradient(90deg,var(--brand),var(--brand-2))}
 
 /* HOME */
-.hero{display:grid;grid-template-columns:1.2fr 1fr;gap:16px;align-items:center}
-.hero-text h1{margin:0 0 10px 0;font-size:32px}
-.hero-art{height:240px;border-radius:14px;background:linear-gradient(135deg,var(--brand-2),#86efac)}
-.features{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-top:16px}
-.feature h3{margin:0 0 6px 0}
-.info { display:flex; gap:16px; flex-wrap:wrap; margin-top:16px; }
-.info .card { flex:1 1 280px; }
-.bullets { display:flex; flex-direction:column; gap:8px; margin:0; padding-left:18px; }
-.testimonials{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:12px}
+.eyebrow{font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:#0f172a6b}
+.hero{display:flex;flex-direction:column;gap:22px;padding:24px}
+.hero-copy{display:grid;gap:12px;max-width:560px;width:100%}
+.hero-copy > *{margin:0}
+.hero-copy .eyebrow{margin-bottom:2px}
+.hero-copy .hero-ctas{margin-top:4px}
+.hero-accent{background:linear-gradient(135deg,#f0fdf4,#dcfce7);border:0;position:relative;overflow:hidden}
+.hero-copy h1{margin:6px 0 12px 0;font-size:30px;line-height:1.2;text-wrap:balance}
+.hero-copy p{margin:0 0 16px 0;font-size:16px;line-height:1.6;text-wrap:pretty}
+.hero-copy .hero-support{margin:0 0 12px 0;font-size:15px;line-height:1.6}
+.hero-copy .hero-support:last-of-type{margin-bottom:0}
+.hero-ctas{display:flex;flex-direction:column;gap:10px;margin:4px 0 12px 0}
+.hero-stats{display:grid;gap:12px;margin:0;padding:0}
+.hero-stats div{display:grid;gap:4px;background:#fff;border-radius:12px;padding:12px 14px;box-shadow:0 8px 20px rgba(15,23,42,.08)}
+.hero-stats dt{font-size:22px;font-weight:800;margin:0}
+.hero-stats dd{margin:0;font-size:13px;line-height:1.4}
+.hero-visual{display:grid;gap:14px}
+.hero-glass{background:rgba(255,255,255,.9);backdrop-filter:blur(6px);border-radius:16px;padding:18px 20px;box-shadow:0 12px 32px rgba(15,23,42,.08);display:grid;gap:12px;text-align:left}
+.badge{display:inline-flex;align-items:center;gap:6px;background:#fef3c7;color:#92400e;border-radius:999px;padding:4px 12px;font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.08em}
+.badge::before{content:"";width:6px;height:6px;border-radius:50%;background:#f59e0b}
+.hero-glass h3{margin:0;font-size:20px}
+.hero-glass .bullets{padding-left:18px;margin:0}
+.mini-card{background:var(--accent);border-radius:14px;padding:12px 14px;border:1px solid rgba(22,101,52,.2);display:grid;gap:4px}
+.hero-art{width:100%;max-width:320px;height:220px;border-radius:20px;object-fit:cover;justify-self:center;box-shadow:0 10px 30px rgba(22,101,52,.25)}
+.bullets{display:flex;flex-direction:column;gap:8px;margin:0;padding-left:18px}
+
+.benefits{display:grid;gap:16px;margin-top:24px}
+.feature-card{display:grid;gap:12px}
+.feature-card h3{margin:0}
+.feature-card p{margin:0}
+
+.snapshot{display:grid;gap:24px;margin-top:28px;align-items:start}
+.snapshot h2{margin:8px 0 12px 0;font-size:24px}
+.snapshot-list{display:grid;gap:16px}
+.snapshot-item{display:flex;gap:14px;align-items:flex-start;padding:14px;border:1px dashed rgba(15,23,42,.08);border-radius:14px;background:#f8fafc}
+.snapshot-item h4{margin:0 0 6px 0}
+.icon-bubble{width:36px;height:36px;border-radius:12px;background:rgba(22,101,52,.12);display:grid;place-items:center;font-size:18px}
+
+.testimonials{display:grid;gap:20px;margin-top:32px}
+.testimonials-head{display:flex;flex-direction:column;gap:12px}
+.testimonial-controls{display:flex;gap:10px}
+.carousel-btn{width:42px;height:42px;border-radius:50%;border:1px solid rgba(15,23,42,.1);background:#fff;box-shadow:0 6px 16px rgba(15,23,42,.08);display:grid;place-items:center;color:var(--text);font-size:16px;cursor:pointer;transition:transform .2s ease,box-shadow .2s ease}
+.carousel-btn:hover{transform:translateY(-1px);box-shadow:0 10px 20px rgba(15,23,42,.12)}
+.carousel-btn:disabled{opacity:.45;cursor:not-allowed;box-shadow:none;transform:none}
+.testimonial-window{overflow-x:auto;overflow-y:hidden;scroll-behavior:smooth;padding-bottom:6px}
+.testimonial-window::-webkit-scrollbar{display:none}
+.testimonial-track{display:flex;gap:16px;scroll-snap-type:x mandatory;padding-bottom:4px}
+.testimonial-card{flex:0 0 100%;scroll-snap-align:start;background:#fff;border:1px solid rgba(15,23,42,.08);border-radius:18px;padding:20px;box-shadow:0 10px 20px rgba(15,23,42,.08);display:grid;gap:12px}
+.testimonial-card blockquote{margin:0;font-size:18px;line-height:1.5;font-weight:600;color:#0f172a}
+.testimonial-card cite{font-style:normal;color:var(--brand);font-weight:700}
+.carousel-dots{display:flex;gap:8px;justify-content:center}
+.carousel-dots button{width:10px;height:10px;border-radius:50%;border:0;background:rgba(15,23,42,.15);padding:0;cursor:pointer}
+.carousel-dots button.active{background:var(--brand)}
+
+@media (min-width: 600px){
+  .hero-ctas{flex-direction:row}
+  .hero-stats{grid-template-columns:repeat(2,minmax(0,1fr))}
+}
+
+@media (min-width: 768px){
+  .hero{flex-direction:row;align-items:center;padding:28px}
+  .hero-copy{flex:1}
+  .hero-copy h1{font-size:34px}
+  .hero-visual{justify-items:end}
+  .hero-art{max-width:360px;height:260px}
+  .benefits{grid-template-columns:repeat(3,minmax(0,1fr))}
+  .snapshot{grid-template-columns:1.2fr 1fr;align-items:center}
+  .snapshot-list{gap:18px}
+  .testimonials-head{flex-direction:row;align-items:center;justify-content:space-between}
+  .testimonial-card{flex:0 0 calc(50% - 8px)}
+}
+
+@media (min-width: 1024px){
+  .hero{padding:32px 36px}
+  .hero-copy h1{font-size:38px}
+  .hero-stats{grid-template-columns:repeat(3,minmax(0,1fr))}
+  .testimonial-card{flex:0 0 calc(33.333% - 10.6px)}
+}
 
 /* LOGIN */
 .login h2{margin:0 0 6px 0}
@@ -108,14 +177,32 @@ input, select{border:1px solid var(--border);border-radius:10px;padding:10px;bac
 
 /* ===== Responsive Flex Tweaks ===== */
 @media (max-width: 768px) {
-  .hero { display: flex; flex-direction: column; }
-  .hero-art { width:100%; height:180px; margin-top:12px; }
+  .hero { padding:24px 18px 28px; gap:24px; }
+  .hero-copy h1 { font-size:28px; line-height:1.25; }
+  .hero-copy p { font-size:15px; line-height:1.6; }
+  .hero-ctas { flex-direction:column; gap:12px; }
+  .hero-ctas .btn{width:100%;justify-content:center}
+  .hero-visual { display:flex; flex-direction:column; gap:18px; align-items:center; text-align:left; width:100%; margin-top:4px; }
+  .hero-visual > *{max-width:360px;width:100%;}
+  .hero-visual .hero-glass { width:100%; max-width:360px; }
+  .hero-art { width:100%; max-width:360px; height:auto; aspect-ratio:4/3; margin:0; }
+  .hero-stats { display:flex; gap:12px; overflow-x:auto; padding-bottom:6px; scroll-snap-type:x proximity; scrollbar-width:none; margin-top:8px; }
+  .hero-stats::-webkit-scrollbar { display:none; }
+  .hero-stats div { min-width:160px; scroll-snap-align:start; flex:0 0 auto; }
+  .hero-stats dt{font-size:20px}
+  .hero-stats dd{font-size:12px;line-height:1.4}
   .features { display:flex; flex-direction:column; }
   .modules-grid { display:flex; flex-direction:column; }
   .bank-hero { display:flex; flex-direction:column; }
   .bank-img { height:200px; }
   .testimonials{grid-template-columns:1fr}
   .tool-grid{grid-template-columns:1fr}
+}
+@media (max-width: 520px) {
+  .hero-copy h1 { font-size:26px; }
+  .hero-visual .hero-glass { padding:16px 18px; }
+  .hero-glass h3 { font-size:18px; }
+  .hero-glass .bullets { font-size:14px; }
 }
 @media (max-width: 600px){
   .hamb{display:block}


### PR DESCRIPTION
## Summary
- split the hero intro copy into two focused paragraphs and balance button styling
- refresh the mobile hero layout with centered imagery, responsive spacing, and balanced typography
- enable horizontal scrolling stats chips and tighten testimonial card glass spacing on small screens

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ded4ff32548326b3b6f37199e5c6d5