### PR TITLE
Revamp landing page layout

### DIFF
--- a/home.html
+++ b/home.html
@@ -23,7 +23,7 @@
           </p>
           <div class="hero-ctas">
             <div class="cta-stack">
-              <button class="btn primary" id="btnStart">Start your free trial</button>
+              <button class="btn primary" id="btnStart">Start free program</button>
               <p class="cta-note">No card required. Cancel anytime.</p>
             </div>
             <a class="btn accent" href="modules.html">Preview festive programs</a>

--- a/styles.css
+++ b/styles.css
@@ -6,12 +6,16 @@
   --nav-glass:rgba(255,255,255,.9);
 }
 *{box-sizing:border-box}
-body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--text)}
+body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:radial-gradient(circle at top,#f1f5f9 0%,#f6f7f9 42%,#f0fdf4 100%);color:var(--text);min-height:100vh}
 .hidden{display:none}
 .tiny{font-size:12px}
 .center{text-align:center}
 
-.container{max-width:1100px;margin:24px auto;padding:0 16px}
+.container{max-width:1120px;margin:24px auto;padding:0 16px}
+main#page-home{display:grid;gap:72px;margin:0;padding:32px 0 80px}
+main#page-home > section{margin:0}
+main#page-home > .container{margin:0 auto}
+main#page-home .hero .container{margin:0 auto}
 .card{background:var(--card);border:1px solid var(--border);border-radius:16px;box-shadow:0 8px 20px rgba(17,24,39,.04);padding:16px}
 
 /* NAV */
@@ -61,38 +65,38 @@ body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetic
 
 /* HOME */
 .eyebrow{font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:#0f172a6b}
-.hero{position:relative;overflow:hidden}
+.hero{position:relative;overflow:hidden;border-radius:0 0 48px 48px;box-shadow:0 40px 120px rgba(15,23,42,.15)}
 .hero::after{content:"";position:absolute;inset:0;background:radial-gradient(120% 120% at 20% 0%,rgba(34,197,94,.16) 0%,rgba(34,197,94,0) 55%);mix-blend-mode:multiply;pointer-events:none}
-.hero-content{display:flex;flex-direction:column;gap:32px;padding:54px 0 60px;position:relative;z-index:1}
+.hero-content{display:flex;flex-direction:column;gap:32px;padding:72px 0 80px;position:relative;z-index:1}
 .hero-copy{display:grid;gap:16px;max-width:560px;width:100%}
 .hero-copy > *{margin:0}
 .hero-copy .hero-ctas{margin-top:6px}
 .seasonal-hook{display:grid;gap:8px;background:linear-gradient(120deg,rgba(255,255,255,.92),rgba(253,230,138,.55));border:1px solid rgba(249,115,22,.25);border-radius:18px;padding:16px 18px;box-shadow:0 18px 36px rgba(249,115,22,.18)}
 .badge.warm{background:rgba(249,115,22,.15);color:#9a3412}
 .hero-accent{background:linear-gradient(135deg,#f0fdf4 0%,#dcfce7 45%,#bbf7d0 100%);border:0}
-.hero-copy h1{margin:6px 0 12px 0;font-size:32px;line-height:1.18;text-wrap:balance}
-.hero-copy p{margin:0 0 16px 0;font-size:16px;line-height:1.65;text-wrap:pretty}
+.hero-copy h1{margin:6px 0 12px 0;font-size:40px;line-height:1.1;text-wrap:balance}
+.hero-copy p{margin:0 0 16px 0;font-size:17px;line-height:1.65;text-wrap:pretty}
 .hero-copy .hero-support{margin:0 0 12px 0;font-size:15px;line-height:1.6}
 .hero-copy .hero-support:last-of-type{margin-bottom:0}
-.hero-ctas{display:flex;flex-direction:column;gap:14px;margin:4px 0 12px 0}
+.hero-ctas{display:flex;flex-direction:column;gap:16px;margin:4px 0 16px 0}
 .cta-stack{display:grid;gap:8px}
 .cta-note{margin:0;font-size:13px;color:#0f172aab}
-.module-highlight{display:grid;gap:12px;margin-top:16px;padding:20px 22px;border-radius:20px;background:linear-gradient(135deg,rgba(255,255,255,.82),rgba(240,253,244,.62));border:1px solid rgba(22,101,52,.12);box-shadow:0 18px 40px rgba(15,23,42,.12)}
+.module-highlight{display:grid;gap:12px;margin-top:16px;padding:22px 24px;border-radius:24px;background:linear-gradient(135deg,rgba(255,255,255,.9),rgba(240,253,244,.72));border:1px solid rgba(22,101,52,.1);box-shadow:0 26px 46px rgba(15,23,42,.12)}
 .module-text h3{margin:0;font-size:22px;line-height:1.35}
 .module-text p{margin:6px 0 0 0;font-size:15px;line-height:1.6}
 .module-points{margin:0;display:grid;gap:8px;padding-left:18px;font-weight:600;color:#0f172a;list-style:none}
 .module-points li{position:relative;padding-left:20px;font-size:15px;line-height:1.5}
 .module-points li::before{content:"";position:absolute;left:0;top:8px;width:10px;height:10px;border-radius:4px;background:linear-gradient(135deg,var(--brand),var(--brand-2));box-shadow:0 6px 12px rgba(22,101,52,.3)}
-.hero-stats{display:grid;gap:12px;margin:4px 0 0 0;padding:0}
-.hero-stats div{display:grid;gap:4px;background:linear-gradient(135deg,rgba(255,255,255,.92),rgba(236,254,244,.72));border-radius:14px;padding:14px 16px;box-shadow:0 12px 28px rgba(15,23,42,.1);border:1px solid rgba(22,101,52,.12)}
-.hero-stats dt{font-size:22px;font-weight:800;margin:0}
-.hero-stats dd{margin:0;font-size:13px;line-height:1.4}
+.hero-stats{display:grid;gap:14px;margin:12px 0 0 0;padding:0}
+.hero-stats div{display:grid;gap:4px;background:linear-gradient(135deg,rgba(255,255,255,.96),rgba(220,252,231,.72));border-radius:18px;padding:18px 20px;box-shadow:0 22px 40px rgba(15,23,42,.12);border:1px solid rgba(22,101,52,.1)}
+.hero-stats dt{font-size:28px;font-weight:800;margin:0}
+.hero-stats dd{margin:0;font-size:14px;line-height:1.45}
 .hero-visual{flex:1;display:flex;justify-content:flex-end;align-items:center}
-.hero-scene{position:relative;display:grid;place-items:end;width:100%;max-width:600px;padding:18px 26px 32px;border-radius:42px;
-  background:linear-gradient(145deg,rgba(15,118,110,.18),rgba(6,95,70,.05));overflow:hidden}
+.hero-scene{position:relative;display:grid;place-items:end;width:100%;max-width:600px;padding:24px 30px 36px;border-radius:42px;
+  background:linear-gradient(155deg,rgba(15,118,110,.25),rgba(6,78,59,.08));overflow:hidden}
 .hero-scene::before{content:"";position:absolute;inset:22px;border-radius:36px;background:radial-gradient(120% 140% at 12% 8%,rgba(248,250,252,.9) 0%,rgba(240,253,244,.5) 45%,rgba(15,118,110,.18) 100%);z-index:0;filter:blur(.2px)}
 .hero-photo{position:relative;z-index:1;width:100%;max-width:560px;height:auto;aspect-ratio:4/5;object-fit:cover;border-radius:34px;
-  border:4px solid rgba(255,255,255,.7);box-shadow:0 36px 70px rgba(15,23,42,.28)}
+  border:5px solid rgba(255,255,255,.82);box-shadow:0 44px 72px rgba(15,23,42,.28)}
 .scene-badge{position:absolute;top:32px;left:38px;z-index:2;display:inline-flex;align-items:center;gap:8px;padding:8px 16px;border-radius:999px;
   background:rgba(15,118,110,.88);color:#ecfdf5;font-size:12px;letter-spacing:.08em;text-transform:uppercase;font-weight:700;box-shadow:0 12px 24px rgba(15,118,110,.35)}
 .scene-badge::before{content:"";width:8px;height:8px;border-radius:50%;background:linear-gradient(135deg,#f97316,#facc15);box-shadow:0 0 0 4px rgba(249,115,22,.25)}
@@ -115,18 +119,18 @@ body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetic
 .feature-points li{position:relative;padding-left:18px}
 .feature-points li::before{content:"";position:absolute;left:0;top:8px;width:8px;height:8px;border-radius:50%;background:linear-gradient(135deg,var(--brand),var(--accent-warm))}
 
-.benefits{display:grid;gap:16px;margin-top:40px}
-.feature-card{display:grid;gap:12px}
+.benefits{display:grid;gap:20px;margin-top:0}
+.feature-card{display:grid;gap:14px;padding:26px;border-radius:24px;background:linear-gradient(135deg,#ffffff 0%,#f0fdf4 80%);box-shadow:0 18px 44px rgba(15,23,42,.08);border:1px solid rgba(15,118,110,.08)}
 .feature-card h3{margin:0}
 .feature-card p{margin:0}
 
-.snapshot{display:grid;gap:24px;margin-top:40px;align-items:start}
+.snapshot{display:grid;gap:30px;align-items:start;padding:34px;border-radius:28px;box-shadow:0 24px 60px rgba(15,23,42,.08);background:linear-gradient(135deg,#ffffff 0%,#f8fafc 45%,#ecfdf5 100%);border:1px solid rgba(15,23,42,.06)}
 .snapshot h2{margin:8px 0 12px 0;font-size:24px}
 .snapshot-list{display:grid;gap:16px}
-.snapshot-item{display:flex;gap:14px;align-items:flex-start;padding:14px;border:1px dashed rgba(15,23,42,.08);border-radius:14px;background:#f8fafc}
+.snapshot-item{display:flex;gap:16px;align-items:flex-start;padding:16px;border:1px dashed rgba(15,23,42,.1);border-radius:16px;background:#f8fafc}
 .snapshot-item h4{margin:0 0 6px 0}
-.icon-bubble{width:48px;height:48px;border-radius:16px;background:rgba(15,118,110,.12);display:grid;place-items:center;font-size:20px}
-.icon-bubble svg{width:26px;height:26px;fill:#0f766e}
+.icon-bubble{width:52px;height:52px;border-radius:18px;background:linear-gradient(135deg,rgba(13,148,136,.16),rgba(45,212,191,.08));display:grid;place-items:center;font-size:20px;box-shadow:0 18px 32px rgba(15,118,110,.18)}
+.icon-bubble svg{width:28px;height:28px;fill:#0f766e}
 
 .accent-slab{background:linear-gradient(120deg,rgba(12,83,54,.9),rgba(6,95,70,.92)),url('img/img2.png') center/cover;border-radius:0;margin:0;color:#f8fafc}
 .accent-slab .container{margin:0 auto;padding:0 16px}
@@ -144,7 +148,7 @@ body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetic
 .banking-points li{position:relative;padding-left:16px;list-style:none}
 .banking-points li::before{content:"";position:absolute;left:0;top:7px;width:8px;height:8px;border-radius:50%;background:linear-gradient(135deg,#f97316,#fde68a)}
 
-.testimonials{display:grid;gap:20px;margin-top:40px}
+.testimonials{display:grid;gap:28px}
 .testimonials-head{display:flex;flex-direction:column;gap:12px}
 .testimonial-controls{display:flex;gap:10px}
 .carousel-btn{width:42px;height:42px;border-radius:50%;border:1px solid rgba(15,23,42,.1);background:#fff;box-shadow:0 6px 16px rgba(15,23,42,.08);display:grid;place-items:center;color:var(--text);font-size:16px;cursor:pointer;transition:transform .2s ease,box-shadow .2s ease}
@@ -153,7 +157,7 @@ body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetic
 .testimonial-window{overflow-x:auto;overflow-y:hidden;scroll-behavior:smooth;padding-bottom:6px}
 .testimonial-window::-webkit-scrollbar{display:none}
 .testimonial-track{display:flex;gap:16px;scroll-snap-type:x mandatory;padding-bottom:4px}
-.testimonial-card{flex:0 0 100%;scroll-snap-align:start;background:#fff;border:1px solid rgba(15,23,42,.08);border-radius:20px;padding:22px;box-shadow:0 18px 36px rgba(15,23,42,.1);display:grid;gap:14px;min-height:260px}
+.testimonial-card{flex:0 0 100%;scroll-snap-align:start;background:#fff;border:1px solid rgba(15,23,42,.08);border-radius:22px;padding:26px;box-shadow:0 26px 44px rgba(15,23,42,.12);display:grid;gap:16px;min-height:260px}
 .testimonial-person{display:flex;gap:12px;align-items:center}
 .avatar{width:52px;height:52px;border-radius:50%;display:grid;place-items:center;font-weight:700;color:#fff;box-shadow:0 12px 22px rgba(15,23,42,.12);background:var(--avatar-bg,linear-gradient(135deg,#0f766e,#22d3ee))}
 .avatar::after{content:attr(data-initial);font-size:15px;letter-spacing:.04em}
@@ -168,7 +172,7 @@ body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetic
 .carousel-dots button{width:10px;height:10px;border-radius:50%;border:0;background:rgba(15,23,42,.15);padding:0;cursor:pointer}
 .carousel-dots button.active{background:var(--brand)}
 
-.trust-band{background:#0b1120;padding:32px 0;margin-top:56px}
+.trust-band{background:#0b1120;padding:48px 0;margin-top:40px}
 .trust-inner{display:grid;gap:18px;align-items:center;text-align:center}
 .trust-inner p{margin:0;color:#94a3b8;font-size:14px;letter-spacing:.06em;text-transform:uppercase}
 .trust-logos{margin:0;padding:0;list-style:none;display:flex;flex-wrap:wrap;gap:18px;justify-content:center}
@@ -190,7 +194,7 @@ body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetic
 }
 
 @media (min-width: 600px){
-  .hero-content{gap:40px;padding:60px 0 72px}
+  .hero-content{gap:44px;padding:80px 0 96px}
   .hero-ctas{flex-direction:row;align-items:flex-start}
   .hero-ctas .cta-stack{flex:1}
   .hero-stats{grid-template-columns:repeat(2,minmax(0,1fr))}
@@ -211,8 +215,8 @@ body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetic
 }
 
 @media (min-width: 1024px){
-  .hero-content{padding:72px 0 96px}
-  .hero-copy h1{font-size:38px}
+  .hero-content{padding:96px 0 120px}
+  .hero-copy h1{font-size:44px}
   .hero-stats{grid-template-columns:repeat(3,minmax(0,1fr))}
   .hero-photo{max-width:580px}
   .testimonial-card{flex:0 0 calc(33.333% - 10.6px)}
@@ -269,6 +273,7 @@ input, select{border:1px solid var(--border);border-radius:10px;padding:10px;bac
 
 /* ===== Responsive Flex Tweaks ===== */
 @media (max-width: 768px) {
+  main#page-home { gap:56px; padding:24px 0 64px; }
   .hero-content { padding:44px 0 52px; }
   .hero-copy h1 { font-size:28px; line-height:1.25; }
   .hero-copy p { font-size:15px; line-height:1.6; }
@@ -281,8 +286,8 @@ input, select{border:1px solid var(--border);border-radius:10px;padding:10px;bac
   .hero-stats { display:flex; gap:12px; overflow-x:auto; padding-bottom:6px; scroll-snap-type:x proximity; scrollbar-width:none; margin-top:8px; }
   .hero-stats::-webkit-scrollbar { display:none; }
   .hero-stats div { min-width:160px; scroll-snap-align:start; flex:0 0 auto; }
-  .hero-stats dt{font-size:20px}
-  .hero-stats dd{font-size:12px;line-height:1.4}
+  .hero-stats dt{font-size:24px}
+  .hero-stats dd{font-size:13px;line-height:1.45}
   .features { display:flex; flex-direction:column; }
   .modules-grid { display:flex; flex-direction:column; }
   .bank-hero { display:flex; flex-direction:column; }


### PR DESCRIPTION
## Summary
- restyle the home hero and CTA copy to align with the provided landing page design
- refresh global and section-specific styling with gradients, card treatments, and refined spacing for the landing sections
- tune responsive rules so the updated layout adapts cleanly across breakpoints

## Testing
- python -m http.server 8000 (manual visual verification)


------
https://chatgpt.com/codex/tasks/task_e_68deedd392848326bf440a88312dc3e7